### PR TITLE
Replace `sqrtm` with `sqrt{m}` in `2017-04-10-alquier17a.md`

### DIFF
--- a/_posts/2017-04-10-alquier17a.md
+++ b/_posts/2017-04-10-alquier17a.md
@@ -7,7 +7,7 @@ abstract: We consider the problem of transfer learning in an online setting. Dif
   the next.  We show that when the within-task algorithm comes with some regret bound,
   our strategy inherits this good property.  Our bounds are in expectation for a general
   loss function, and uniform for a convex loss. We discuss applications to dictionary
-  learning and finite set of predictors. In the latter case, we improve previous $O(1/\sqrtm)$
+  learning and finite set of predictors. In the latter case, we improve previous $O(1/\sqrt{m})$
   bounds  to $O(1/m)$, where $m$ is the per task sample size.
 layout: inproceedings
 series: Proceedings of Machine Learning Research
@@ -27,7 +27,7 @@ author:
 - given: Massimiliano
   family: Pontil
 date: 2017-04-10
-address: 
+address:
 publisher: PMLR
 container-title: Proceedings of the 20th International Conference on Artificial Intelligence
   and Statistics


### PR DESCRIPTION
I found a minor error in the abstract as in the screenshot. This PR fixes the math notation.

<img width="261" alt="Screenshot 2022-04-02 at 3 59 26" src="https://user-images.githubusercontent.com/7121753/161325269-ddbec419-2ec9-4e3f-be79-709360313cfe.png">

